### PR TITLE
Added and documented ability to set request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ while($x < 10) { //retry the call up to 10 times if it fails
 	}
 }
 
+// You can set a request timeout, after which a ContextIO\cURLException will be thrown if 
+// no response has been received from the API
+$contextio->getRequestClass()->setRequestTimeout(10);
+
 ```
 
 All methods are listed in src/ContextIO/ContextIO.php

--- a/src/ContextIO/ContextIO.php
+++ b/src/ContextIO/ContextIO.php
@@ -63,6 +63,15 @@ class ContextIO
     }
     
     /**
+     * Returns the request class.
+     * @return RequestInterface
+     */
+    public function getRequestClass()
+    {
+        return $this->requestClass;
+    }
+
+    /**
      * Attempts to discover IMAP settings for a given email address
      * @link http://context.io/docs/2.0/discovery
      *

--- a/src/ContextIO/ContextIORequest.php
+++ b/src/ContextIO/ContextIORequest.php
@@ -243,7 +243,7 @@ class ContextIORequest implements RequestInterface
         
         $errno = curl_errno($curl);
         if (!empty($errno)) {
-            throw new cURLException($curl);
+            throw new cURLException($curl, $errno);
         }
         
         if ($this->saveHeaders) {


### PR DESCRIPTION
Started out as a bugfix for cURLException ($errno was not supplied - needs backporting to 2.x-branch as well but I have only supplied a PR for this branch), but then also realized that:

1. A request timeout can not be set without being able to access the request class
2. With the new refactoring, the ability to set timeouts etc can be removed from the official lib and instead implemented locally via extension of the request class - nice!

